### PR TITLE
Update method for combined data store

### DIFF
--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -574,6 +574,10 @@ do
 		self:_Update()
 	end
 
+	function CombinedDataStore:Update(updateFunc)
+		self:Set(updateFunc(self:Get()));
+	end
+
 	function CombinedDataStore:OnUpdate(callback)
 		self.combinedStore:OnUpdate(function(value)
 			if value[self.combinedName] == nil then

--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -575,7 +575,7 @@ do
 	end
 
 	function CombinedDataStore:Update(updateFunc)
-		self:Set(updateFunc(self:Get()));
+		self:Set(updateFunc(self:Get()))
 	end
 
 	function CombinedDataStore:OnUpdate(callback)


### PR DESCRIPTION
I noticed that when using :Update method on a combined data store it pass the entire data on the updateFunc

```
// Combine some stores among "inventory"
local ds = DataStore2("inventory", player)
local get_output = ds:Get();
// get_ouput = {item_count = 0, items = {}}
ds:Update(function(inventory)
    // inventory = {{item_count = 0, items = {}}, {other_data_store_combined_with_inventory...}}
end)
```

So I added the update method in CombinedDataStore and now "inventory" variable is same as "get_output". I am pretty sure that the implementation is correct, it invokes onupdate events since uses :Set and seem to work as expected