### PR TITLE
:DataStore2(dataStoreName, player) type checking

### DIFF
--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -109,7 +109,7 @@ function Verifier.scanValidity(tbl, passed, path)
 end
 
 function Verifier.getStringPath(path)
-	return table.concat(path, '.')
+	return table.concat(path, ".")
 end
 
 function Verifier.warnIfInvalid(input)
@@ -636,6 +636,7 @@ function DataStore2.ClearCache()
 end
 
 function DataStore2:__call(dataStoreName, player)
+	assert(typeof(dataStoreName) == "string" and typeof(player) == "Instance", "DataStore2() API call expected {string dataStoreName, Instance player}, got {Instance player, string dataStoreName}")
 	if DataStoreCache[player] and DataStoreCache[player][dataStoreName] then
 		return DataStoreCache[player][dataStoreName]
 	elseif combinedDataStoreInfo[dataStoreName] then

--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -636,7 +636,7 @@ function DataStore2.ClearCache()
 end
 
 function DataStore2:__call(dataStoreName, player)
-	assert(typeof(dataStoreName) == "string" and typeof(player) == "Instance", "DataStore2() API call expected {string dataStoreName, Instance player}, got {Instance player, string dataStoreName}")
+	assert(typeof(dataStoreName) == "string" and typeof(player) == "Instance", ("DataStore2() API call expected {string dataStoreName, Instance player}, got {%s, %s}"):format(typeof(dataStoreName), typeof(player)))
 	if DataStoreCache[player] and DataStoreCache[player][dataStoreName] then
 		return DataStoreCache[player][dataStoreName]
 	elseif combinedDataStoreInfo[dataStoreName] then


### PR DESCRIPTION
:DataStore2() API call arguments are type checked to assure the user is correctly using the feature, spits out a descriptive error if the user isn't (validates dataStoreName is a string and player is an Instance).

I also modified a single line to change single quotes into double quotes for consistency, didn't think it was large enough to make it's own PR.