### PR TITLE
Update DataStore2.module.lua

### DIFF
--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -722,9 +722,9 @@ function DataStore2:__call(dataStoreName, player)
 		end
 	end)
 
-	local playerLeavingEvent
-	playerLeavingEvent = player.AncestryChanged:Connect(function()
-		playerLeavingEvent:Disconnect()
+	local playerLeavingConnection
+	playerLeavingConnection = player.AncestryChanged:Connect(function()
+		playerLeavingConnection:Disconnect()
 		dataStore:Save()
 		event:Fire()
 		fired = true

--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -722,16 +722,16 @@ function DataStore2:__call(dataStoreName, player)
 		end
 	end)
 
-	Players.PlayerRemoving:connect(function(playerLeaving)
-		if playerLeaving == player then
-			dataStore:Save()
-			event:Fire()
-			fired = true
+	local playerLeavingEvent;
+	playerLeavingEvent = player.AncestryChanged:Connect(function()
+		playerLeavingEvent:Disconnect()
+		dataStore:Save()
+		event:Fire()
+		fired = true
 
-			delay(40, function() --Give a long delay for people who haven't figured out the cache :^(
-				DataStoreCache[playerLeaving] = nil
-			end)
-		end
+		delay(40, function() --Give a long delay for people who haven't figured out the cache :^(
+			DataStoreCache[player] = nil
+		end)
 	end)
 
 	if not DataStoreCache[player] then

--- a/DataStore2.module.lua
+++ b/DataStore2.module.lua
@@ -722,7 +722,7 @@ function DataStore2:__call(dataStoreName, player)
 		end
 	end)
 
-	local playerLeavingEvent;
+	local playerLeavingEvent
 	playerLeavingEvent = player.AncestryChanged:Connect(function()
 		playerLeavingEvent:Disconnect()
 		dataStore:Save()


### PR DESCRIPTION
replaced PlayerRemoving for individual players with player.AncestryChanged, and have it disconnect itself to prevent a memory leak