### PR TITLE
Parent the player to nil on :BindToClose()

### DIFF
--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -619,6 +619,7 @@ function DataStore2:__call(dataStoreName, player)
 	local event, fired = Instance.new("BindableEvent"), false
 
 	game:BindToClose(function()
+		player.Parent = nil
 		if not fired then
 			event.Event:wait()
 		end


### PR DESCRIPTION
This would solve #45 as the player being parented to nil fires the AncestryChanged event.