### PR TITLE
Update init.lua

### DIFF
--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -137,10 +137,9 @@ function DataStore:Get(defaultValue, dontAttemptGet)
 end
 
 function DataStore:GetAsync(...)
-	local length = select("#", ...)
-	local args = {...}
+	local args = { ... }
 	return Promise.async(function(resolve)
-		resolve(self:Get(unpack(args, 1, length)))
+		resolve(self:Get(unpack(args)))
 	end)
 end
 


### PR DESCRIPTION
Made the code a little faster (I've heard things about DataStore2 having a significant startup time, this might help a little with that) and made the code more consistent.

- Changed the regular `unpack` in `::GetAsync` to include a length argument, since it's usually faster (?).
- Changed any `pairs` to `ipairs` if I know they are an array.
- Made the `dataStore` table properties (not sure the word to use) inside the table instead of outside if possible.
- Made some of the code more consistent like:
  - Instead of `table.insert` and `x[#x + 1]`, I made them all `table.insert` for readability sake (yes, it's slower, but it's more readable).
  - Got rid of the spaces between `{}` where there were any, as the majority of the code doesn't have that formatting.
  - Added trailing commas where there weren't any, since that was how more of the code was setup.