### PR TITLE
Fix issue with multiple nested keys

### DIFF
--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -496,7 +496,9 @@ function DataStore2.__call(_, dataStoreName, player)
 					local value = combinedStore:Get(nil, true)
 					if value ~= nil then
 						if combinedStore.combinedBeforeSave then
-							value = combinedStore.combinedBeforeSave(clone(value))
+							if typeof(value) == "table" then
+								value = combinedStore.combinedBeforeSave(clone(value))
+							end
 						end
 						combinedData[key] = value
 					end


### PR DESCRIPTION
An issue arises when Combining multiple keys, ie. PlayerData < CurrencyData < Coins, Gems. When trying to save Coins and Gems, the error: Error on BeforeSave: ServerStorage.DataStore2:583: bad argument #1 to 'pairs' (table expected, got number)" would occur.