### PR TITLE
Fix _Update firing twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix a crash relating to backups.
 - Fix `GetTable` not working appropriately when using different default table keys.
 - Fix `GetTable` not working appropriately when using combined data stores.
-- Fix `:IncrementAsync` not returning a Promise
+- Fix `:IncrementAsync` not returning a Promise.
+- Fix `OnUpdate` being fired twice when using `Update` to update data.
 
 ## [1.3.0]
 - Added :GetAsync(), :GetTableAsync, and :IncrementAsync(), which are [promise](https://github.com/evaera/roblox-lua-promise) versions of their non-async counterparts.

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -398,7 +398,6 @@ do
 
 	function CombinedDataStore:Update(updateFunc)
 		self:Set(updateFunc(self:Get()))
-		self:_Update()
 	end
 
 	function CombinedDataStore:Save()

--- a/Tests/tests/DataStore2.spec.lua
+++ b/Tests/tests/DataStore2.spec.lua
@@ -327,6 +327,21 @@ return function()
 				expect(timesCalled2).to.equal(1)
 			end)
 
+			it("should call OnUpdate callbacks when using Update", function()
+				local dataStore = DataStore2(UUID(), fakePlayer)
+				
+				local timesCalled = 0
+				dataStore:OnUpdate(function()
+					timesCalled = timesCalled + 1
+				end)
+
+				dataStore:Update(function(oldValue)
+					return (oldValue or 0) + 1
+				end)
+
+				expect(timesCalled).to.equal(1)
+			end)
+
 			it("should not call OnUpdate when using :Get() with a default value", function()
 				local dataStore = DataStore2(UUID(), fakePlayer)
 				local called = false


### PR DESCRIPTION
This pull request fixes Update on combined DataStores firing OnUpdate twice, and creates a unit test to ensure this behavior remains consistent.

Closes #83 