### PR TITLE
Update GetTableAsync to patch tables inside the value

### DIFF
--- a/DataStore2/TableUtil.lua
+++ b/DataStore2/TableUtil.lua
@@ -17,17 +17,17 @@ end
 function TableUtil.sync(tbl, default)
 	local changed = false
 
-	for key, value in pairs(default) do
-		if not tbl[key] then
-			if typeof(value) == "table" then
-				tbl[key] = TableUtil.copy(value)
+	for defaultKey, defaultValue in pairs(default) do
+		if tbl[defaultKey] == nil then
+			if typeof(defaultValue) == "table" then
+				tbl[defaultKey] = TableUtil.copy(defaultValue)
 			else
-				tbl[key] = value
+				tbl[defaultKey] = defaultValue
 			end
 
 			changed = true
-		elseif typeof(tbl[key]) == "table" then
-			TableUtil.sync(tbl[key], value)
+		elseif typeof(tbl[defaultKey]) == "table" then
+			TableUtil.sync(tbl[defaultKey], defaultValue)
 		end
 	end
 

--- a/DataStore2/TableUtil.lua
+++ b/DataStore2/TableUtil.lua
@@ -14,4 +14,24 @@ function TableUtil.clone(tbl)
 	return clone
 end
 
+function TableUtil.sync(tbl, default)
+	local changed = false
+
+	for key, value in pairs(default) do
+		if not tbl[key] then
+			if typeof(value) == "table" then
+				tbl[key] = TableUtil.copy(value)
+			else
+				tbl[key] = value
+			end
+
+			changed = true
+		elseif typeof(tbl[key]) == "table" then
+			TableUtil.sync(tbl[key], value)
+		end
+	end
+
+	return changed
+end
+
 return TableUtil

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -171,7 +171,7 @@ function DataStore:GetTableAsync(default, ...)
 
 		return result
 	end)
-endd
+end
 
 function DataStore:Set(value, _dontCallOnUpdate)
 	self.value = clone(value)

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -158,18 +158,12 @@ function DataStore:GetTableAsync(default, ...)
 	assert(default ~= nil, "You must provide a default value.")
 
 	return self:GetAsync(default, ...):andThen(function(result)
-		local changed = false
 		assert(
 			typeof(result) == "table",
 			":GetTable/:GetTableAsync was used when the value in the data store isn't a table."
 		)
 
-		for defaultKey, defaultValue in pairs(default) do
-			if result[defaultKey] == nil then
-				result[defaultKey] = defaultValue
-				changed = true
-			end
-		end
+		local changed = TableUtil.sync(result, default)
 
 		if changed then
 			self:Set(result)
@@ -177,7 +171,7 @@ function DataStore:GetTableAsync(default, ...)
 
 		return result
 	end)
-end
+endd
 
 function DataStore:Set(value, _dontCallOnUpdate)
 	self.value = clone(value)


### PR DESCRIPTION
Currently, `DataStore:GetTableAsync(default)` only patches missing keys on the first "layer" of the DataStore value.
If the value itself contains tables, it will not sync with the respective default value.

e.g.
If the value looks like this:
```lua
{
    Equipped = "Default",
    Owned = {
        Backpack = true
    }
}
```
and `default` looks like this:
```lua
{
    Equipped = "Default",
    Owned = {
        Default = true
    }
}
```
`Owned.Default = true` will not be added to the DataStore value.

Solution:
`TableUtil.sync(tbl, default) -> bool`
Adds missing keys to `tbl` from `default`. If `tbl` contains table values, TableUtil.sync will be used on those table values.
Returns whether `tbl` was changed at all.

When `DataStore:GetTableAsync(default)` is called, it should now sync the DataStore value with `default`, where if the value itself contains a table, it will sync that table with the respective table value in `default`.