### PR TITLE
BindToClose issue fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix `GetTable` not working appropriately when using combined data stores.
 - Fix `:IncrementAsync` not returning a Promise.
 - Fix `OnUpdate` being fired twice when using `Update` to update data.
+- Fix `BindToClose` memory leak, breaking other BindToClose scripts, and potential error.
 
 ## [1.3.0]
 - Added :GetAsync(), :GetTableAsync, and :IncrementAsync(), which are [promise](https://github.com/evaera/roblox-lua-promise) versions of their non-async counterparts.

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -560,13 +560,18 @@ function DataStore2.__call(_, dataStoreName, player)
 		end
 	end
 
-	game:BindToClose(function()
-		if bindToCloseCallback == nil then
-			return
-		end
-
-		bindToCloseCallback()
+	local success, errorMessage = pcall(function()
+		game:BindToClose(function()
+			if bindToCloseCallback == nil then
+				return
+			end
+	
+			bindToCloseCallback()
+		end)
 	end)
+	if success == false then
+		warn(errorMessage)
+	end
 
 	Promise.race({
 		Promise.fromEvent(bindToCloseEvent.Event),

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -545,7 +545,7 @@ function DataStore2.__call(_, dataStoreName, player)
 
 	local event, fired = Instance.new("BindableEvent"), false
 
-	game:BindToClose(function()
+	local bindToCloseCallback = function()
 		if not fired then
 			spawn(function()
 				player.Parent = nil -- Forces AncestryChanged to fire and save the data
@@ -559,6 +559,14 @@ function DataStore2.__call(_, dataStoreName, player)
 		for _, bindToClose in ipairs(dataStore.bindToClose) do
 			bindToClose(player, value)
 		end
+	end
+
+	game:BindToClose(function()
+		if bindToCloseCallback == nil then
+			return
+		end
+
+		bindToCloseCallback()
 	end)
 
 	local playerLeavingConnection
@@ -577,6 +585,7 @@ function DataStore2.__call(_, dataStoreName, player)
 
 		delay(40, function() --Give a long delay for people who haven't figured out the cache :^(
 			DataStoreCache[player] = nil
+			bindToCloseCallback = nil
 		end)
 	end)
 

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -1,6 +1,5 @@
 --[[
-	DataStore2: A wrapper for data stores that caches, saves player's data, and uses berezaa's method of saving data.
-	Use require(1936396537) to have an updated version of DataStore2.
+	DataStore2: A wrapper for data stores that caches and saves player's data.
 
 	DataStore2(dataStoreName, player) - Returns a DataStore2 DataStore
 

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -570,7 +570,7 @@ function DataStore2.__call(_, dataStoreName, player)
 		end)
 	end)
 	if success == false then
-		warn(errorMessage)
+		warn("DataStore2 could not BindToClose", errorMessage)
 	end
 
 	Promise.race({

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -547,7 +547,7 @@ function DataStore2.__call(_, dataStoreName, player)
 	local bindToCloseEvent = Instance.new("BindableEvent")
 
 	local bindToCloseCallback = function()
-		if isSaveFinished == false then
+		if not isSaveFinished then
 			bindToCloseEvent:Fire()
 
 			saveFinishedEvent.Event:Wait()
@@ -569,14 +569,14 @@ function DataStore2.__call(_, dataStoreName, player)
 			bindToCloseCallback()
 		end)
 	end)
-	if success == false then
+	if not success then
 		warn("DataStore2 could not BindToClose", errorMessage)
 	end
 
 	Promise.race({
 		Promise.fromEvent(bindToCloseEvent.Event),
 		Promise.fromEvent(player.AncestryChanged, function()
-			return player:IsDescendantOf(game) == false
+			return not player:IsDescendantOf(game)
 		end),
 	}):andThen(function()
 		dataStore:SaveAsync():andThen(function()
@@ -594,7 +594,9 @@ function DataStore2.__call(_, dataStoreName, player)
 			DataStoreCache[player] = nil
 			bindToCloseCallback = nil
 		end)
-	end):catch(warn)
+	end):catch(function(errorMessage)
+		warn("DataStore2 could not save data when the player left", errorMessage)
+	end)
 
 	if not DataStoreCache[player] then
 		DataStoreCache[player] = {}

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -548,7 +548,10 @@ function DataStore2.__call(_, dataStoreName, player)
 
 	local bindToCloseCallback = function()
 		if not isSaveFinished then
-			bindToCloseEvent:Fire()
+			-- Defer to avoid a race between connecting and firing "saveFinishedEvent"
+			Promise.defer(function()
+				bindToCloseEvent:Fire() -- Resolves the Promise.race to save the data
+			end)
 
 			saveFinishedEvent.Event:Wait()
 		end

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -594,8 +594,6 @@ function DataStore2.__call(_, dataStoreName, player)
 			DataStoreCache[player] = nil
 			bindToCloseCallback = nil
 		end)
-	end):catch(function(errorMessage)
-		warn("DataStore2 could not save data when the player left", errorMessage)
 	end)
 
 	if not DataStoreCache[player] then


### PR DESCRIPTION
Addressed Issue #124 by moving the BindToClose function to a separate callback which is set to nil once the player leaves.

Addressed Issue #125 by using a BindableEvent to trigger the final save of player's data instead of setting the player object's parent to nil.  Promises seem to be an elegant way to handle the AncestryChanged and the new BindableEvent's connection.

Addressed Issue #126 by wrapping the BindToClose function in a pcall to prevent errors if the game shuts down before the BindToClose function has finished.