### PR TITLE
Add read-only store for offline users

### DIFF
--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -485,6 +485,7 @@ DataStoreMetatable.__index = DataStore
 
 --Library
 local DataStoreCache = {}
+local ReadOnlyDataStoreCache = {}
 
 local DataStore2 = {}
 local combinedDataStoreInfo = {}
@@ -512,6 +513,7 @@ end
 
 function DataStore2.ClearCache()
 	DataStoreCache = {}
+	ReadOnlyDataStoreCache = {}
 end
 
 function DataStore2.SaveAll(player)
@@ -547,8 +549,8 @@ function DataStore2.FromUserId(dataStoreName, userId)
 		)
 	)
 
-	if DataStoreCache[userId] and DataStoreCache[userId][dataStoreName] then
-		return DataStoreCache[userId][dataStoreName]
+	if ReadOnlyDataStoreCache[userId] and ReadOnlyDataStoreCache[userId][dataStoreName] then
+		return ReadOnlyDataStoreCache[userId][dataStoreName]
 	elseif combinedDataStoreInfo[dataStoreName] then
 		local dataStore = DataStore2.FromUserId(combinedDataStoreInfo[dataStoreName], userId)
 
@@ -561,18 +563,18 @@ function DataStore2.FromUserId(dataStoreName, userId)
 			end,
 		})
 
-		if not DataStoreCache[userId] then
-			DataStoreCache[userId] = {}
+		if not ReadOnlyDataStoreCache[userId] then
+			ReadOnlyDataStoreCache[userId] = {}
 		end
 
-		DataStoreCache[userId][dataStoreName] = combinedStore
+		ReadOnlyDataStoreCache[userId][dataStoreName] = combinedStore
 		return combinedStore
 	end
 
 	local dataStore = {
+		readOnly = true,
 		Name = dataStoreName,
 		UserId = userId,
-		readOnly = true,
 		callbacks = {},
 		beforeInitialGet = {},
 		afterSave = {},
@@ -583,11 +585,11 @@ function DataStore2.FromUserId(dataStoreName, userId)
 
 	setmetatable(dataStore, DataStoreMetatable)
 
-	if not DataStoreCache[userId] then
-		DataStoreCache[userId] = {}
+	if not ReadOnlyDataStoreCache[userId] then
+		ReadOnlyDataStoreCache[userId] = {}
 	end
 
-	DataStoreCache[userId][dataStoreName] = dataStore
+	ReadOnlyDataStoreCache[userId][dataStoreName] = dataStore
 
 	return dataStore
 end

--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -608,8 +608,13 @@ function DataStore2.__call(_, dataStoreName, identifier)
 
 	local player = IsPlayer.Check(identifier) and identifier or Players:GetPlayerByUserId(identifier)
 	if player == nil then
-		-- User is not in this server, return a read-only store
-		return DataStore2.ReadOnly(dataStoreName, identifier)
+		-- User is not in this server, tell dev to use a read-only store instead
+		error(string.format(
+			"Cannot create DataStore for '%s' since that user is not in this server.\nYou can use DataStore2.ReadOnly('%s', %s) instead.",
+			tostring(identifier), dataStoreName, tostring(identifier)
+		), 2)
+
+		--return DataStore2.ReadOnly(dataStoreName, identifier) -- automatically make readonly store instead
 	end
 
 	if DataStoreCache[player] and DataStoreCache[player][dataStoreName] then


### PR DESCRIPTION
**This is still a WIP. I am creating this Draft PR so that the work is public to be discussed and iterated upon. It is not ready for merging.**

_Relates to Issue https://github.com/Kampfkarren/Roblox/issues/44._

------------------

The main thing holding back offline user datastores is (from what I have heard) that the user might be online in another server, effectively being in two places at once- creating race conditions and overwrites and possibly even duplication if the user is malicious. We would also lose any hopes of adding session-locking, since they can be in multiple sessions with that.

That's a hard problem to solve. I attempted using MsgService to communicate changes across servers, but it wasn't robust nor reliable enough for me to use. Like all those who tried before me, I gave it up pretty fast.

But then I realized that something is better than nothing. In my personal use case, I actually only ever need to _read_ an offline player's data. In fact, that seems to be the most common use for offline data- even the original issue is phrased to be about _getting_ player data.
Instead of solving the really difficult issue of multi-session writing, I've added a bit of functionality that is useful for a fair few cases, and it can act as a stepping stone towards solving the full problem later on. It's better than doing nothing at all, I think.

------------------

I've added `DataStore2.ReadOnly(datastoreName, player | userId)` to explicitly and descriptively have a way to create read only stores.
(To keep the APIs feeling consistent, I've made `DataStore2()`'s second arg allow userId as well.)
If you pass a player/userId to `DataStore2()` that is not in the server, it will error and suggest you make a `DataStore2.ReadOnly()` instead.

------------------

To Do:

- [x] Add dataStore.readOnly protection _(prevent all writing/saving of that store)_
- [x] Add DS2.ReadOnly _(create a read-only store from Player/UserId)_
- [ ] Add replication _(update/set/save replicating to the read-only stores of other servers)_
- [ ] Add cleanup _(offline stores aren't tied to a player leaving and require manual cleanup)_


