### PR TITLE
Add Wally manifest file

### DIFF
--- a/wally.toml
+++ b/wally.toml
@@ -1,0 +1,8 @@
+[package]
+name = "kampfkarren/roblox"
+license = "https://raw.githubusercontent.com/Kampfkarren/Roblox/master/LICENSE"
+version = "1.4.0"
+registry = "https://github.com/UpliftGames/wally-index"
+realm = "shared"
+
+[dependecies]


### PR DESCRIPTION
This Pull Request adds a [Wally](https://github.com/UpliftGames/wally) manifest file for the latest release of DataStore2.

The below is for adding it to an existing roblox project using rojo
```toml
[dependencies]
DataStore2 = "kampfkarren/roblox@1.4.0"
```

```bash
$ wally install
[INFO ] Updating package index...
[INFO ] Downloading kampfkarren/roblox@1.4.0
```