### PR TITLE
feature/GDPR-Tags: Added additional Datastore 2.0 GDPR tag support

### DIFF
--- a/DataStore2/SavingMethods/OrderedBackups.lua
+++ b/DataStore2/SavingMethods/OrderedBackups.lua
@@ -46,11 +46,12 @@ function OrderedBackups:Set(value)
 	local key = (self.mostRecentKey or 0) + 1
 
 	return Promise.async(function(resolve)
-		self.dataStore:SetAsync(key, value)
+		self.dataStore:SetAsync(key, value, { self.dataStore2.UserId })
+
 		resolve()
 	end):andThen(function()
 		return Promise.promisify(function()
-			self.orderedDataStore:SetAsync(key, key)
+			self.orderedDataStore:SetAsync(key, key, { self.dataStore2.UserId })
 		end)()
 	end):andThen(function()
 		self.mostRecentKey = key

--- a/DataStore2/SavingMethods/Standard.lua
+++ b/DataStore2/SavingMethods/Standard.lua
@@ -15,11 +15,9 @@ end
 
 function Standard:Set(value)
 	return Promise.async(function(resolve)
-		self.dataStore:UpdateAsync(self.userId, function()
-			return value
-		end)
+		self.dataStore:GetAsync(self.userId)
 
-		resolve()
+		resolve(self.dataStore:SetAsync(self.userId, value, { self.userId }))
 	end)
 end
 

--- a/DataStore2/SavingMethods/Standard.lua
+++ b/DataStore2/SavingMethods/Standard.lua
@@ -9,15 +9,25 @@ Standard.__index = Standard
 
 function Standard:Get()
 	return Promise.async(function(resolve)
-		resolve(self.dataStore:GetAsync(self.userId))
+		self.storeData = self.dataStore:GetAsync(self.userId)
+
+		resolve(self.storeData)
 	end)
 end
 
 function Standard:Set(value)
 	return Promise.async(function(resolve)
-		self.dataStore:GetAsync(self.userId)
+		local datastoreKeyResponse
 
-		resolve(self.dataStore:SetAsync(self.userId, value, { self.userId }))
+		if self.storeData == nil then
+			datastoreKeyResponse = self.dataStore:SetAsync(self.userId, value, { self.userId })
+		else
+			datastoreKeyResponse = self.dataStore:UpdateAsync(self.userId, function()
+				return value
+			end)
+		end
+
+		resolve(datastoreKeyResponse)
 	end)
 end
 


### PR DESCRIPTION
# Context

The Issue https://github.com/Kampfkarren/Roblox/issues/143 was opened but never addressed, this PR is an attempt at addressing this issue. 

# This PR
- Additional call for `:GetAsync` to implement the same behavior as `:UpdateAsync`
- Updated `SavingMethods/Standard.lua` to support the `userIds` array Datastore 2.0 provides.