### PR TITLE
feature/Datastore2-GDPR-Tags: Add support for DataStore2.0 GDPR Tags

### DIFF
--- a/DataStore2/SavingMethods/OrderedBackups.lua
+++ b/DataStore2/SavingMethods/OrderedBackups.lua
@@ -46,11 +46,11 @@ function OrderedBackups:Set(value)
 	local key = (self.mostRecentKey or 0) + 1
 
 	return Promise.async(function(resolve)
-		self.dataStore:SetAsync(key, value)
+		self.dataStore:SetAsync(key, value, { self.dataStore2.UserId })
 		resolve()
 	end):andThen(function()
 		return Promise.promisify(function()
-			self.orderedDataStore:SetAsync(key, key)
+			self.orderedDataStore:SetAsync(key, key, { self.dataStore2.UserId })
 		end)()
 	end):andThen(function()
 		self.mostRecentKey = key

--- a/DataStore2/SavingMethods/Standard.lua
+++ b/DataStore2/SavingMethods/Standard.lua
@@ -16,7 +16,7 @@ end
 function Standard:Set(value)
 	return Promise.async(function(resolve)
 		self.dataStore:UpdateAsync(self.userId, function()
-			return value
+			return value, { self.userId }
 		end)
 
 		resolve()


### PR DESCRIPTION
## Context
Support for adding GDPR tags into the DataStore2 Lib. I've previously attempted to do this, however have ran into a few different technicalities I needed to research on. 

This PR should address and bring in the GDPR features this library is missing.

## This PR
- [Add support for DataStore2.0 GDPR Tags](https://github.com/Kampfkarren/Roblox/commit/a1000c22d23a85acfa775c7e10428a6deddb061c)

