### PR TITLE
Add `CombinedDataStore:AfterSave()`

### DIFF
--- a/DataStore2/init.lua
+++ b/DataStore2/init.lua
@@ -424,6 +424,16 @@ do
 	function CombinedDataStore:SetBackup(retries)
 		self.combinedStore:SetBackup(retries)
 	end
+
+	function CombinedDataStore:AfterSave(callback)
+		local function wrappedCallback(save)
+			local saveValue = save[self.combinedName]
+			
+			return callback(saveValue)
+		end
+		
+		self.combinedStore:AfterSave(wrappedCallback)
+	end
 end
 
 local DataStoreMetatable = {}


### PR DESCRIPTION
Resolves #96

For a combined store, the after-save hook passes the *entire* combined store to the callback. This PR will ensure that only the relevant data associated with the `dataStoreName` provided at `__call` is passed into the user-provided callback function.

This is my first PR here, so any feedback/critique would be much appreciated :)